### PR TITLE
Fix cpu gpu transfers

### DIFF
--- a/amazon-google.py
+++ b/amazon-google.py
@@ -11,12 +11,13 @@ from utils.index_utils import build_index, search_index
 
 if __name__ == "__main__":
 
-    print("Start blocking...")
     blocking_start = time.time()
     parser = argparse.ArgumentParser()
     parser.add_argument('--batch_size', type=int, default=1, help='Batch size for DataLoader')
     args = parser.parse_args()
     batch_size = args.batch_size
+
+    print("Start blocking for batch size: ", batch_size)
 
     # load Table A
     cwd = os.path.dirname(os.path.abspath(__file__))

--- a/utils/embedding_model.py
+++ b/utils/embedding_model.py
@@ -45,10 +45,7 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel):
         # Normalize embeddings
         embeddings = F.normalize(embeddings, p=2, dim=1)
 
-        if self.device == 'cuda':
-            return embeddings
-        else:
-            return embeddings.cpu().numpy()
+        return embeddings
 
 def _mean_pooling(model_output, attention_mask):
     token_embeddings = model_output[0]  # First element of model_output contains all token embeddings

--- a/utils/index_utils.py
+++ b/utils/index_utils.py
@@ -1,24 +1,23 @@
-from faiss import Index
 from torch.utils.data import DataLoader
-
+import faiss
 from utils.dataset import BaseDataset
 from utils.embedding_model import EmbeddingModel
+import faiss.contrib.torch_utils
 
-
-def build_index(dataset: BaseDataset, batch_size: int, embedding_model: EmbeddingModel, faiss_index: Index):
-    dataloader = DataLoader(dataset, batch_size=batch_size)
+def build_index(dataset: BaseDataset, batch_size: int, embedding_model: EmbeddingModel, faiss_index):
+    dataloader = DataLoader(dataset, batch_size=batch_size, pin_memory=True)
     tableA_ids = []
     for batch in dataloader:
         ids = batch['id']
         sentences = batch['text']
         embeddings = embedding_model.get_embedding(sentences)
-        faiss_index.add(embeddings.cpu().numpy())
+        faiss_index.add(embeddings)
         tableA_ids.extend(ids)
     return tableA_ids
 
 
 def search_index(dataset: BaseDataset, batch_size: int,
-                 embedding_model: EmbeddingModel, faiss_index: Index,
+                 embedding_model: EmbeddingModel, faiss_index,
                  top_k: int = 5,
                  tableA_ids: list = None):
     dataloader = DataLoader(dataset, batch_size=batch_size)
@@ -31,9 +30,7 @@ def search_index(dataset: BaseDataset, batch_size: int,
 
         embeddings = embedding_model.get_embedding(sentences)
 
-        embeddings = embeddings.cpu().numpy()
-
-        distances, indices = faiss_index.search(x=embeddings, k=top_k)
+        distances, indices = faiss_index.search(embeddings, top_k)
 
         for i, id in enumerate(ids):
             tableA_matches = [tableA_ids[idx] for idx in indices[i]]

--- a/utils/index_utils.py
+++ b/utils/index_utils.py
@@ -2,7 +2,7 @@ from torch.utils.data import DataLoader
 import faiss
 from utils.dataset import BaseDataset
 from utils.embedding_model import EmbeddingModel
-import faiss.contrib.torch_utils
+import faiss.contrib.torch_utils # need this for GPU support even though you don't use it
 
 def build_index(dataset: BaseDataset, batch_size: int, embedding_model: EmbeddingModel, faiss_index):
     dataloader = DataLoader(dataset, batch_size=batch_size, pin_memory=True)


### PR DESCRIPTION
Removed redundant CPU to GPU transfers between 

Dont see a significant difference for this small dataset but would be significant for larger datasets and multi-GPU setting

Start blocking for batch size:  1000
Using GPU for embedding: NVIDIA A40
Using GPU for FAISS index
Start building index...
Start searching...
Build Index time:  3.5368564128875732
Index search time:  9.524180889129639
Blocking time:  17.780095100402832
Precision: 0.0984
Recall: 0.9837
F1 Score: 0.1789
